### PR TITLE
fix issue #1

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -95,6 +95,9 @@ hrm.onreading = function() {
   let myHRTVal = (hrm.heartRate);
   let myHRTValString = myHRTVal + ""; 
   let hrtArray = [hrt0,hrt1,hrt2];
+  hrt0.image = "";
+  hrt1.image = "";
+  hrt2.image = "";
   for (var j = 0; j < myHRTValString.length; j++) {
     let hrtLetter = myHRTValString.slice(j,j+1) + "-small";
     drawDigit(hrtLetter, hrtArray[j]);


### PR DESCRIPTION
HeartRateの表示を更新する際、いったん画像をクリアする処理を追加
具体的にはhtr0,1,2のimageをいったん""にしているだけです。
svg的に正しいのかは、ちょっと自信がありません。すみません・・・。

現象の原因は、3桁表示→2桁表示となった際、3桁目に古い表示が残りっぱなしになるということだと思われます。恐らくすでに原因は把握なさっているとは思うのですが、一応報告まで。
